### PR TITLE
Add new async keywords.

### DIFF
--- a/grammars/dart.cson
+++ b/grammars/dart.cson
@@ -129,6 +129,10 @@
         'name': 'keyword.control.dart'
       }
       {
+        'match': '\\b(sync\\*|async(\\*)?|await|yield(\\*)?)'
+        'name': 'keyword.control.dart'
+      }
+      {
         'match': '\\b(new)\\b'
         'name': 'keyword.control.new.dart'
       }


### PR DESCRIPTION
sync*, async, async*, yield, yield*, and await

The spec is here: https://www.dartlang.org/docs/spec/Asyncdraft-TC52.pdf but Seth Ladd seems confident enough to open a pull request for these keywords here: https://github.com/dart-lang/dart-sublime-bundle/issues/227

(note: he seems to be wrong about some of those keywords)